### PR TITLE
Implement dynamic profile loading

### DIFF
--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -35,7 +35,9 @@
                 <i class="bi bi-star-fill text-warning" v-for="n in prof.rating" :key="n"></i>
                 <i class="bi bi-star" v-for="n in (5 - prof.rating)" :key="n"></i>
               </div>
-              <button class="btn btn-primary btn-sm">Ver perfil</button>
+              <router-link :to="{ name: 'Profile', params: { id: index } }" class="btn btn-primary btn-sm">
+                Ver perfil
+              </router-link>
             </div>
           </div>
         </div>

--- a/src/pages/ProfilePage.vue
+++ b/src/pages/ProfilePage.vue
@@ -77,17 +77,57 @@ import DefaultLayout from '../layouts/DefaultLayout.vue'
 
 export default {
   components: { DefaultLayout },
+  props: ['id'],
   data() {
-    return {
-      profile: {
-        nombre: 'Juan Pérez',
+    const perfiles = [
+      {
+        nombre: 'Ana Pérez',
+        servicio: 'Electricista',
+        experiencia: '5 años',
+        formacion: 'Curso Avanzado de Electricidad - INADEH 2022',
+        zona: 'Ciudad de Panamá',
+        foto: 'https://placehold.co/100',
+        trabajos: [
+          'https://placehold.co/150/FFAA00',
+          'https://placehold.co/150/FFAA00',
+          'https://placehold.co/150/FFAA00',
+          'https://placehold.co/150/FFAA00'
+        ],
+        opiniones: [
+          {
+            nombre: 'Luis Solís',
+            rating: 5,
+            comentario: 'Muy profesional y puntual.'
+          }
+        ]
+      },
+      {
+        nombre: 'Pedro Martínez',
+        servicio: 'Electricista',
+        experiencia: '2 años',
+        formacion: 'Técnico en Electricidad - INADEH 2021',
+        zona: 'Colón',
+        foto: 'https://placehold.co/100',
+        trabajos: [
+          'https://placehold.co/150/00AAFF',
+          'https://placehold.co/150/00AAFF'
+        ],
+        opiniones: [
+          {
+            nombre: 'Carlos Pérez',
+            rating: 4,
+            comentario: 'Buen servicio.'
+          }
+        ]
+      },
+      {
+        nombre: 'Juan González',
         servicio: 'Electricista',
         experiencia: '3 años',
         formacion: 'Curso de Electricidad - INADEH 2023',
         zona: 'Santiago',
         foto: 'https://placehold.co/100',
         trabajos: [
-          'https://placehold.co/150',
           'https://placehold.co/150',
           'https://placehold.co/150',
           'https://placehold.co/150'
@@ -105,6 +145,11 @@ export default {
           }
         ]
       }
+    ]
+
+    const index = parseInt(this.id, 10)
+    return {
+      profile: perfiles[index] || perfiles[0]
     }
   }
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -23,9 +23,10 @@ const routes = [
         component: ContactPage
     },
     {
-        path: '/profile',
+        path: '/profile/:id',
         name: 'Profile',
-        component: ProfilePage
+        component: ProfilePage,
+        props: true
     }
 ]
 


### PR DESCRIPTION
## Summary
- allow profile pages to receive an `id` param
- link each worker on the home page to their own profile
- load example profile data based on that id

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686feec7ed248328994d1f76d70c82de