### PR TITLE
Add share modal and home navigation

### DIFF
--- a/src/components/ShareModal.vue
+++ b/src/components/ShareModal.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="modal-overlay" @click.self="close">
+    <div class="modal-content bg-white p-4 rounded">
+      <h5 class="mb-3">Escoge donde compartir</h5>
+      <div class="d-flex justify-content-around mb-4">
+        <i class="bi bi-facebook fs-1 text-primary"></i>
+        <i class="bi bi-twitter fs-1 text-info"></i>
+        <i class="bi bi-whatsapp fs-1 text-success"></i>
+        <i class="bi bi-instagram fs-1 text-danger"></i>
+      </div>
+      <div class="text-end">
+        <button class="btn btn-primary me-2" @click="close">Aceptar</button>
+        <button class="btn btn-secondary" @click="close">Cancelar</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  emits: ['close'],
+  methods: {
+    close() {
+      this.$emit('close')
+    }
+  }
+}
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(5px);
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1050;
+}
+.modal-content {
+  max-width: 300px;
+}
+</style>

--- a/src/pages/ProfilePage.vue
+++ b/src/pages/ProfilePage.vue
@@ -61,22 +61,25 @@
 
       <!-- Botones de acción -->
       <div class="d-flex justify-content-between mt-4">
-        <button class="btn btn-secondary">
+        <router-link to="/" class="btn btn-secondary">
           <i class="bi bi-arrow-left"></i> Regresar
-        </button>
-        <button class="btn btn-primary">
+        </router-link>
+        <button class="btn btn-primary" @click="openShare">
           <i class="bi bi-share-fill"></i> Compartir
         </button>
       </div>
+
+      <ShareModal v-if="showModal" @close="closeShare" />
     </div>
   </DefaultLayout>
 </template>
 
 <script>
 import DefaultLayout from '../layouts/DefaultLayout.vue'
+import ShareModal from '../components/ShareModal.vue'
 
 export default {
-  components: { DefaultLayout },
+  components: { DefaultLayout, ShareModal },
   props: ['id'],
   data() {
     const perfiles = [
@@ -149,7 +152,16 @@ export default {
 
     const index = parseInt(this.id, 10)
     return {
-      profile: perfiles[index] || perfiles[0]
+      profile: perfiles[index] || perfiles[0],
+      showModal: false
+    }
+  },
+  methods: {
+    openShare() {
+      this.showModal = true
+    },
+    closeShare() {
+      this.showModal = false
     }
   }
 }


### PR DESCRIPTION
## Summary
- add ShareModal component for sharing profile
- navigate to homepage from the back button
- open ShareModal with share button and blur the background

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff1ab80108328ad760f91d0fab936