### PR TITLE
Fix profile routing and add form validation

### DIFF
--- a/src/data/professionals.js
+++ b/src/data/professionals.js
@@ -1,0 +1,70 @@
+export const defaultProfessionals = [
+  {
+    nombre: 'Ana Pérez',
+    servicio: 'Electricista',
+    rating: 5,
+    foto: 'https://placehold.co/100',
+    experiencia: '5 años',
+    formacion: 'Curso Avanzado de Electricidad - INADEH 2022',
+    zona: 'Ciudad de Panamá',
+    trabajos: [
+      'https://placehold.co/150/',
+      'https://placehold.co/150/',
+      'https://placehold.co/150/',
+      'https://placehold.co/150/'
+    ],
+    opiniones: [
+      {
+        nombre: 'Luis Solís',
+        rating: 5,
+        comentario: 'Muy profesional y puntual.'
+      }
+    ]
+  },
+  {
+    nombre: 'Pedro Martínez',
+    servicio: 'Electricista',
+    rating: 4,
+    foto: 'https://placehold.co/100',
+    experiencia: '2 años',
+    formacion: 'Técnico en Electricidad - INADEH 2021',
+    zona: 'Colón',
+    trabajos: [
+      'https://placehold.co/150/',
+      'https://placehold.co/150/'
+    ],
+    opiniones: [
+      {
+        nombre: 'Carlos Pérez',
+        rating: 4,
+        comentario: 'Buen servicio.'
+      }
+    ]
+  },
+  {
+    nombre: 'Juan González',
+    servicio: 'Electricista',
+    rating: 3,
+    foto: 'https://placehold.co/100',
+    experiencia: '3 años',
+    formacion: 'Curso de Electricidad - INADEH 2023',
+    zona: 'Santiago',
+    trabajos: [
+      'https://placehold.co/150',
+      'https://placehold.co/150',
+      'https://placehold.co/150'
+    ],
+    opiniones: [
+      {
+        nombre: 'Maria Gomez',
+        rating: 5,
+        comentario: 'Realizó un trabajo excelente, muy recomendado 5 estrellas.'
+      },
+      {
+        nombre: 'Joana Lopez',
+        rating: 4,
+        comentario: 'Realizó una buena instalación.'
+      }
+    ]
+  }
+]

--- a/src/pages/ApplyPage.vue
+++ b/src/pages/ApplyPage.vue
@@ -2,22 +2,26 @@
   <DefaultLayout>
     <div class="container py-5">
       <h1 class="mb-4">Aplicar como Profesional</h1>
-      <form @submit.prevent="submitForm">
+      <form @submit.prevent="submitForm" novalidate>
         <div class="mb-3">
           <label class="form-label">Nombre</label>
-          <input type="text" class="form-control" v-model="form.nombre" required />
+          <input type="text" class="form-control" v-model="form.nombre" />
+          <div v-if="errors.nombre" class="form-text text-danger">{{ errors.nombre }}</div>
         </div>
         <div class="mb-3">
           <label class="form-label">Teléfono</label>
-          <input type="text" class="form-control" v-model="form.telefono" required />
+          <input type="text" class="form-control" v-model="form.telefono" />
+          <div v-if="errors.telefono" class="form-text text-danger">{{ errors.telefono }}</div>
         </div>
         <div class="mb-3">
           <label class="form-label">Correo</label>
-          <input type="email" class="form-control" v-model="form.email" required />
+          <input type="email" class="form-control" v-model="form.email" />
+          <div v-if="errors.email" class="form-text text-danger">{{ errors.email }}</div>
         </div>
         <div class="mb-3">
           <label class="form-label">Profesión/Servicio</label>
-          <input type="text" class="form-control" v-model="form.servicio" required />
+          <input type="text" class="form-control" v-model="form.servicio" />
+          <div v-if="errors.servicio" class="form-text text-danger">{{ errors.servicio }}</div>
         </div>
         <div class="mb-3">
           <label class="form-label">Formación</label>
@@ -35,6 +39,7 @@
 
 <script>
 import DefaultLayout from '../layouts/DefaultLayout.vue'
+import { defaultProfessionals } from '../data/professionals'
 
 export default {
   components: { DefaultLayout },
@@ -47,21 +52,48 @@ export default {
         servicio: '',
         formacion: '',
         zona: ''
-      }
+      },
+      errors: {}
     }
   },
   methods: {
     submitForm() {
-      const stored = JSON.parse(localStorage.getItem('profesionales')) || []
+      this.errors = {}
+      if (!this.form.nombre.trim()) {
+        this.errors.nombre = 'Nombre requerido'
+      }
+      if (!/^\d{7,}$/.test(this.form.telefono)) {
+        this.errors.telefono = 'Teléfono inválido'
+      }
+      const emailRegex = /.+@.+\..+/
+      if (!emailRegex.test(this.form.email)) {
+        this.errors.email = 'Correo inválido'
+      }
+      if (!this.form.servicio.trim()) {
+        this.errors.servicio = 'Servicio requerido'
+      }
+
+      if (Object.keys(this.errors).length) {
+        return
+      }
+
+      let stored = JSON.parse(localStorage.getItem('profesionales'))
+      if (!stored) {
+        stored = [...defaultProfessionals]
+      }
+
       stored.push({
         nombre: this.form.nombre,
         servicio: this.form.servicio,
         rating: 0,
-        foto: 'https://placehold.co/80',
+        foto: 'https://placehold.co/100',
         telefono: this.form.telefono,
         email: this.form.email,
         formacion: this.form.formacion,
-        zona: this.form.zona
+        zona: this.form.zona,
+        experiencia: '',
+        trabajos: [],
+        opiniones: []
       })
       localStorage.setItem('profesionales', JSON.stringify(stored))
       this.$router.push('/')

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -48,23 +48,21 @@
 
 <script>
 import DefaultLayout from '../layouts/DefaultLayout.vue'
+import { defaultProfessionals } from '../data/professionals'
 
 export default {
   components: { DefaultLayout },
   data() {
-    const defaultProfesionales = [
-      { nombre: 'Ana Pérez', servicio: 'Electricista', rating: 5, foto: 'https://placehold.co/80' },
-      { nombre: 'Pedro Martínez', servicio: 'Electricista', rating: 4, foto: 'https://placehold.co/80' },
-      { nombre: 'Juan González', servicio: 'Electricista', rating: 3, foto: 'https://placehold.co/80' }
-    ]
+    const defaultProfiles = defaultProfessionals
 
-    const stored = JSON.parse(localStorage.getItem('profesionales'))
+    let stored = JSON.parse(localStorage.getItem('profesionales'))
     if (!stored) {
-      localStorage.setItem('profesionales', JSON.stringify(defaultProfesionales))
+      localStorage.setItem('profesionales', JSON.stringify(defaultProfiles))
+      stored = defaultProfiles
     }
 
     return {
-      profesionales: stored || defaultProfesionales
+      profesionales: stored
     }
   }
 }

--- a/src/pages/ProfilePage.vue
+++ b/src/pages/ProfilePage.vue
@@ -77,82 +77,21 @@
 <script>
 import DefaultLayout from '../layouts/DefaultLayout.vue'
 import ShareModal from '../components/ShareModal.vue'
+import { defaultProfessionals } from '../data/professionals'
 
 export default {
   components: { DefaultLayout, ShareModal },
   props: ['id'],
   data() {
-    const perfiles = [
-      {
-        nombre: 'Ana Pérez',
-        servicio: 'Electricista',
-        experiencia: '5 años',
-        formacion: 'Curso Avanzado de Electricidad - INADEH 2022',
-        zona: 'Ciudad de Panamá',
-        foto: 'https://placehold.co/100',
-        trabajos: [
-          'https://placehold.co/150/',
-          'https://placehold.co/150/',
-          'https://placehold.co/150/',
-          'https://placehold.co/150/'
-        ],
-        opiniones: [
-          {
-            nombre: 'Luis Solís',
-            rating: 5,
-            comentario: 'Muy profesional y puntual.'
-          }
-        ]
-      },
-      {
-        nombre: 'Pedro Martínez',
-        servicio: 'Electricista',
-        experiencia: '2 años',
-        formacion: 'Técnico en Electricidad - INADEH 2021',
-        zona: 'Colón',
-        foto: 'https://placehold.co/100',
-        trabajos: [
-          'https://placehold.co/150/',
-          'https://placehold.co/150/'
-        ],
-        opiniones: [
-          {
-            nombre: 'Carlos Pérez',
-            rating: 4,
-            comentario: 'Buen servicio.'
-          }
-        ]
-      },
-      {
-        nombre: 'Juan González',
-        servicio: 'Electricista',
-        experiencia: '3 años',
-        formacion: 'Curso de Electricidad - INADEH 2023',
-        zona: 'Santiago',
-        foto: 'https://placehold.co/100',
-        trabajos: [
-          'https://placehold.co/150',
-          'https://placehold.co/150',
-          'https://placehold.co/150'
-        ],
-        opiniones: [
-          {
-            nombre: 'Maria Gomez',
-            rating: 5,
-            comentario: 'Realizó un trabajo excelente, muy recomendado 5 estrellas.'
-          },
-          {
-            nombre: 'Joana Lopez',
-            rating: 4,
-            comentario: 'Realizó una buena instalación.'
-          }
-        ]
-      }
-    ]
+    let profiles = JSON.parse(localStorage.getItem('profesionales'))
+    if (!profiles) {
+      localStorage.setItem('profesionales', JSON.stringify(defaultProfessionals))
+      profiles = defaultProfessionals
+    }
 
     const index = parseInt(this.id, 10)
     return {
-      profile: perfiles[index] || perfiles[0],
+      profile: profiles[index] || profiles[0],
       showModal: false
     }
   },


### PR DESCRIPTION
## Summary
- centralize professional profiles in a single module and load them from localStorage
- adjust Home page to use the shared profile data
- fix Profile page to read profiles from localStorage so new workers show the correct profile
- enhance Apply form with validation feedback and store full profile info

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687009a86364832895efeeaee74e9656