### PR TITLE
Improve application form

### DIFF
--- a/src/data/locations.js
+++ b/src/data/locations.js
@@ -1,0 +1,50 @@
+export const locations = {
+  "Panamá": {
+    "Panamá": ["San Francisco", "Betania", "Juan Díaz"],
+    "San Miguelito": ["Belisario Porras", "Arnulfo Arias"],
+    "Chepo": ["Chepo", "Las Margaritas"],
+    "Taboga": ["Taboga", "Otoque Occidente"]
+  },
+  "Panamá Oeste": {
+    "Arraiján": ["Burunga", "Vista Alegre"],
+    "La Chorrera": ["Barrio Colón", "Guadalupe"],
+    "Capira": ["Capira", "Campana"],
+    "Chame": ["Chame", "Bejuco"]
+  },
+  "Coclé": {
+    "Aguadulce": ["Aguadulce", "El Cristo"],
+    "Antón": ["Antón", "Juan Díaz"],
+    "Penonomé": ["Penonomé", "Coclá"],
+    "La Pintada": ["La Pintada", "El Harino"]
+  },
+  "Colón": {
+    "Colón": ["Cativá", "Cristóbal"],
+    "Portobelo": ["Portobelo", "San Felipe"],
+    "Chagres": ["Nueva Providencia", "Piña"]
+  },
+  "Veraguas": {
+    "Santiago": ["Santiago", "La Peña"],
+    "Soná": ["Soná", "Bahía Honda"]
+  },
+  "Chiriquí": {
+    "David": ["David", "Pedregal"],
+    "Boquete": ["Boquete", "Alto Boquete"],
+    "Barú": ["Puerto Armuelles", "Limones"]
+  },
+  "Bocas del Toro": {
+    "Bocas del Toro": ["Isla Colón", "Bastimentos"],
+    "Changuinola": ["Changuinola", "Guabito"]
+  },
+  "Herrera": {
+    "Chitré": ["Chitré", "La Arena"],
+    "Ocú": ["Ocú", "Los Llanos"]
+  },
+  "Los Santos": {
+    "Las Tablas": ["Las Tablas", "San José"],
+    "Guararé": ["Guararé", "El Espinal"]
+  },
+  "Darién": {
+    "Chepigana": ["La Palma", "Garachiné"],
+    "Pinogana": ["El Real de Santa María", "Metetí"]
+  }
+}

--- a/src/data/professionals.js
+++ b/src/data/professionals.js
@@ -13,6 +13,7 @@ export const defaultProfessionals = [
       'https://placehold.co/150/',
       'https://placehold.co/150/'
     ],
+    certificados: [],
     opiniones: [
       {
         nombre: 'Luis Solís',
@@ -33,6 +34,7 @@ export const defaultProfessionals = [
       'https://placehold.co/150/',
       'https://placehold.co/150/'
     ],
+    certificados: [],
     opiniones: [
       {
         nombre: 'Carlos Pérez',
@@ -54,6 +56,7 @@ export const defaultProfessionals = [
       'https://placehold.co/150',
       'https://placehold.co/150'
     ],
+    certificados: [],
     opiniones: [
       {
         nombre: 'Maria Gomez',

--- a/src/data/professions.js
+++ b/src/data/professions.js
@@ -1,0 +1,16 @@
+export const professions = [
+  'Albañil',
+  'Electricista',
+  'Plomero',
+  'Carpintero',
+  'Pintor',
+  'Jardinero',
+  'Cerrajero',
+  'Modista',
+  'Mecánico',
+  'Soldador',
+  'Herrero',
+  'Reparación de Electrodomésticos',
+  'Técnico de Computadoras',
+  'Otra'
+]

--- a/src/pages/ApplyPage.vue
+++ b/src/pages/ApplyPage.vue
@@ -20,7 +20,23 @@
         </div>
         <div class="mb-3">
           <label class="form-label">Profesión/Servicio</label>
-          <input type="text" class="form-control" v-model="form.servicio" />
+          <input
+            class="form-control"
+            list="professionList"
+            v-model="form.servicioSelect"
+            @change="onProfessionChange"
+            placeholder="Seleccione una profesión"
+          />
+          <datalist id="professionList">
+            <option v-for="p in professionOptions" :key="p">{{ p }}</option>
+          </datalist>
+          <input
+            v-if="form.servicioSelect === 'Otra'"
+            type="text"
+            class="form-control mt-2"
+            v-model="form.servicio"
+            placeholder="Especifique su profesión"
+          />
           <div v-if="errors.servicio" class="form-text text-danger">{{ errors.servicio }}</div>
         </div>
         <div class="mb-3">
@@ -28,8 +44,33 @@
           <input type="text" class="form-control" v-model="form.formacion" />
         </div>
         <div class="mb-3">
-          <label class="form-label">Zona</label>
-          <input type="text" class="form-control" v-model="form.zona" />
+          <label class="form-label">Provincia</label>
+          <select class="form-select" v-model="form.provincia">
+            <option value="">Seleccione</option>
+            <option v-for="(d, p) in locationData" :key="p" :value="p">{{ p }}</option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Distrito</label>
+          <select class="form-select" v-model="form.distrito" :disabled="!districts.length">
+            <option value="">Seleccione</option>
+            <option v-for="d in districts" :key="d" :value="d">{{ d }}</option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Corregimiento</label>
+          <select class="form-select" v-model="form.corregimiento" :disabled="!corregimientos.length">
+            <option value="">Seleccione</option>
+            <option v-for="c in corregimientos" :key="c" :value="c">{{ c }}</option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Certificados/Títulos</label>
+          <input type="file" class="form-control" @change="onCertChange" multiple accept="image/*" />
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Fotos de trabajos</label>
+          <input type="file" class="form-control" @change="onWorkChange" multiple accept="image/*" />
         </div>
         <button type="submit" class="btn btn-primary">Enviar</button>
       </form>
@@ -40,6 +81,8 @@
 <script>
 import DefaultLayout from '../layouts/DefaultLayout.vue'
 import { defaultProfessionals } from '../data/professionals'
+import { professions } from '../data/professions'
+import { locations } from '../data/locations'
 
 export default {
   components: { DefaultLayout },
@@ -50,13 +93,60 @@ export default {
         telefono: '',
         email: '',
         servicio: '',
+        servicioSelect: '',
         formacion: '',
-        zona: ''
+        provincia: '',
+        distrito: '',
+        corregimiento: '',
+        certificados: [],
+        trabajos: []
       },
-      errors: {}
+      districts: [],
+      corregimientos: [],
+      errors: {},
+      professionOptions: professions,
+      locationData: locations
     }
   },
-  methods: {
+  watch: {
+    'form.provincia'(val) {
+      this.form.distrito = ''
+      this.form.corregimiento = ''
+      this.districts = val ? Object.keys(this.locationData[val] || {}) : []
+      this.corregimientos = []
+    },
+    'form.distrito'(val) {
+      this.form.corregimiento = ''
+      const prov = this.form.provincia
+      this.corregimientos = prov && val ? this.locationData[prov][val] || [] : []
+    }
+  },
+ methods: {
+    onProfessionChange() {
+      if (this.form.servicioSelect !== 'Otra') {
+        this.form.servicio = this.form.servicioSelect
+      } else {
+        this.form.servicio = ''
+      }
+    },
+    onCertChange(e) {
+      const files = Array.from(e.target.files)
+      files.forEach(f => {
+        const reader = new FileReader()
+        reader.onload = ev => this.form.certificados.push(ev.target.result)
+        reader.readAsDataURL(f)
+      })
+      e.target.value = ''
+    },
+    onWorkChange(e) {
+      const files = Array.from(e.target.files)
+      files.forEach(f => {
+        const reader = new FileReader()
+        reader.onload = ev => this.form.trabajos.push(ev.target.result)
+        reader.readAsDataURL(f)
+      })
+      e.target.value = ''
+    },
     submitForm() {
       this.errors = {}
       if (!this.form.nombre.trim()) {
@@ -69,7 +159,9 @@ export default {
       if (!emailRegex.test(this.form.email)) {
         this.errors.email = 'Correo inválido'
       }
-      if (!this.form.servicio.trim()) {
+      if (!this.form.servicioSelect) {
+        this.errors.servicio = 'Servicio requerido'
+      } else if (this.form.servicioSelect === 'Otra' && !this.form.servicio.trim()) {
         this.errors.servicio = 'Servicio requerido'
       }
 
@@ -84,15 +176,16 @@ export default {
 
       stored.push({
         nombre: this.form.nombre,
-        servicio: this.form.servicio,
+        servicio: this.form.servicioSelect === 'Otra' ? this.form.servicio : this.form.servicioSelect,
         rating: 0,
         foto: 'https://placehold.co/100',
         telefono: this.form.telefono,
         email: this.form.email,
         formacion: this.form.formacion,
-        zona: this.form.zona,
+        zona: `${this.form.provincia}, ${this.form.distrito}, ${this.form.corregimiento}`,
         experiencia: '',
-        trabajos: [],
+        trabajos: this.form.trabajos,
+        certificados: this.form.certificados,
         opiniones: []
       })
       localStorage.setItem('profesionales', JSON.stringify(stored))

--- a/src/pages/ProfilePage.vue
+++ b/src/pages/ProfilePage.vue
@@ -32,6 +32,16 @@
         </div>
       </div>
 
+      <!-- Certificados -->
+      <div class="mb-4" v-if="profile.certificados && profile.certificados.length">
+        <h5 class="mb-3">Certificados</h5>
+        <div class="row">
+          <div class="col-6 col-md-3 mb-3" v-for="(img, i) in profile.certificados" :key="`cert-${i}`">
+            <img :src="img" class="img-fluid rounded" alt="Certificado" />
+          </div>
+        </div>
+      </div>
+
       <!-- Trabajos realizados -->
       <div class="mb-4">
         <h5 class="mb-3">Trabajos realizados</h5>


### PR DESCRIPTION
## Summary
- add new profession list and location data
- allow selecting profession from datalist or custom entry
- add province, district and corregimiento fields
- support uploading certificates and job photos
- display uploaded certificates on the profile page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700e6a656483289d565023e21b1cf9