### PR TITLE
Fix vue-select dependency conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "vite-plugin-pwa": "^1.0.1",
     "vue": "^3.5.17",
     "vue-router": "^4.5.1",
-    "vue-select": "^3.0.0"
+    "vue-select": "^4.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",


### PR DESCRIPTION
## Summary
- update `vue-select` version to use the Vue 3 compatible release

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687016ab463483288270edcbaed0aac5